### PR TITLE
feat(mp): dsv3 support for guided decoding with MTP

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -306,8 +306,10 @@ def create_py_executor_instance(dist,
     if mapping.is_last_pp_rank(
     ) and executor_config.guided_decoding_config is not None:
         if spec_config is not None:
-            raise ValueError(
-                "Guided decoding does not support with speculative decoding.")
+            logger.warning("[BASETEN] MTP with guided decoding 🚀")
+            # [BASETEN] the following error was commented out to support MTP
+            # raise ValueError(
+            #     "Guided decoding is not supported with speculative decoding.")
         resources[
             "guided_decoder_resource_manager"] = GuidedDecoderResourceManager(
                 executor_config.max_batch_size)

--- a/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 import torch
 import xgrammar
+import json
 
 from ...bindings.executor import GuidedDecodingConfig, GuidedDecodingParams
 from .llm_request import LlmRequest
@@ -131,21 +132,28 @@ class GuidedDecoder:
     def execute(self, scheduled_requests: ScheduledRequests,
                 logits: torch.Tensor,
                 resource_manager: GuidedDecoderResourceManager) -> None:
-        assert logits.size(0) == len(scheduled_requests.context_requests) + len(
-            scheduled_requests.generation_requests)
+        # [BASETEN] the following assert was uncommented to support with MTP
+        # assert logits.size(0) == len(scheduled_requests.context_requests) + len(
+        #    scheduled_requests.generation_requests)
         torch.cuda.current_stream().wait_stream(self._stream)
 
         if self.guided_decoding_backend == GuidedDecodingConfig.GuidedDecodingBackend.XGRAMMAR:
             batched_logits, batched_bitmask = [], []
-            for i, llm_req in enumerate(
+            cur_logits_idx = 0
+            next_logits_idx = 0
+            for _, llm_req in enumerate(
                     itertools.chain(scheduled_requests.context_requests,
                                     scheduled_requests.generation_requests)):
+                cur_logits_idx = next_logits_idx
+                next_logits_idx += 1 + llm_req.num_draft_tokens
                 if llm_req.guided_decoding_params is None:
                     continue
                 if llm_req.is_context_init_state and not llm_req.is_last_context_chunk(
                 ):
                     continue
-                batched_logits.append(logits[i])
+
+                # [BASETEN] adjust the indices to work with MTP (cur_logits_idx, next_logits_idx vs i)
+                batched_logits.append(logits[cur_logits_idx])
                 slot = resource_manager.slot_manager.get_slot(
                     llm_req.request_id)
                 batched_bitmask.append(self.bitmask[slot])

--- a/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 
 import torch
 import xgrammar
-import json
 
 from ...bindings.executor import GuidedDecodingConfig, GuidedDecodingParams
 from .llm_request import LlmRequest

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -1,3 +1,4 @@
+import itertools
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -12,7 +13,6 @@ from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
 from ..pyexecutor.resource_manager import BaseResourceManager, SlotManager
 from ..pyexecutor.scheduler import ScheduledRequests
 from .interface import SpecConfig, SpecMetadata, SpeculativeDecodingMode
-import itertools
 
 
 @dataclass
@@ -253,11 +253,15 @@ class MTPDecoder(TorchDecoder):
         ### BASETEN MTP-GUIDED SUPPORT BEGIN
         logits = model_outputs['logits']
 
-        guided_decoding_mask = torch.zeros(next_draft_tokens_device.shape[0], device=next_draft_tokens_device.device)
+        guided_decoding_mask = torch.zeros(
+            next_draft_tokens_device.shape[0],
+            device=next_draft_tokens_device.device)
         guided_decoding_indices = []
         cur_logits_idx = 0
         next_logits_idx = 0
-        for i, request in enumerate(itertools.chain(scheduled_requests.context_requests, scheduled_requests.generation_requests)):
+        for i, request in enumerate(
+                itertools.chain(scheduled_requests.context_requests,
+                                scheduled_requests.generation_requests)):
             # TODO(mahmoud, perf): build guided_decoding_mask and guided_decoding_indices in self.update_requests?
             cur_logits_idx = next_logits_idx
             next_logits_idx += 1 + request.num_draft_tokens
@@ -265,22 +269,29 @@ class MTPDecoder(TorchDecoder):
                 guided_decoding_mask[i] = 1
                 guided_decoding_indices.append(cur_logits_idx)
 
-        new_tokens_greedy_device = torch.argmax(logits[guided_decoding_indices], dim=-1)
-
         if len(guided_decoding_indices) > 0:
+            # MTP decoding uses next_new_tokens_device (from the MTP worker) to get the next token.
+            # For guided decoding, we need to use greedy sampling on the logits instead.
+            new_tokens_greedy_device = torch.argmax(
+                logits[guided_decoding_indices], dim=-1)
             cpy_new_tokens = new_tokens_device.clone()
-            cpy_new_tokens[:, 0] = new_tokens_device[:, 0] * (1 - guided_decoding_mask) + new_tokens_greedy_device * guided_decoding_mask
+            cpy_new_tokens[:, 0] = new_tokens_device[:, 0] * (
+                1 - guided_decoding_mask
+            ) + new_tokens_greedy_device * guided_decoding_mask
             new_tokens_device = cpy_new_tokens
 
             cpy_next_new_tokens = next_new_tokens_device.clone()
-            cpy_next_new_tokens[:, 0] = cpy_next_new_tokens[:, 0] * (1 - guided_decoding_mask) + new_tokens_greedy_device * guided_decoding_mask
+            cpy_next_new_tokens[:, 0] = cpy_next_new_tokens[:, 0] * (
+                1 - guided_decoding_mask
+            ) + new_tokens_greedy_device * guided_decoding_mask
             next_new_tokens_device = cpy_next_new_tokens
 
             # set lens to 1 for these
             cpy_lens = new_tokens_lens_device.clone()
-            cpy_lens[:] = cpy_lens * (1 - guided_decoding_mask) + 1 * guided_decoding_mask
+            cpy_lens[:] = cpy_lens * (
+                1 - guided_decoding_mask) + 1 * guided_decoding_mask
             new_tokens_lens_device = cpy_lens
-        
+
         ### BASETEN MTP-GUIDED SUPPORT END
 
         new_tokens_host = new_tokens_device.to('cpu', non_blocking=True)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
trtllm dsv3 to support MTP with guided decoding.
<!--
  How was the change described above implemented?
-->
## :computer: How
Selectively disable MTP for guided-decoding requests by running custom logic in the MTP decoder method.
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

- [X] sent requests with and without structured outputs requests. looked at the output to confirm the structuring. Used the LLM API directly (not dynamo or trtllm-serve).
Batch of 4 requests, where the third request does no structured output:
```
[0] Prompt: 'Bad wifi network', Generated text: '{  \n    "ssid": "Bad wifi network",\n    "securityProtocol": "WPA2",\n    "bandwidth":  "1000 Mbps"\n}'
[1] Prompt: 'Good wifi network', Generated text: '{ \t"ssid": "your_ssid", \t"securityProtocol": "your_security_protocol", \t"bandwidth": "your_bandwidth" }'
[2] Prompt: "Michael Jackson's wifi network", Generated text: ' is called "MJFam" and "MJFam2". The password is "mjfamrocks". Michael Jackson\'s wifi network is named after his fans, known as the "MJ Fam". The password reflects his appreciation for his dedicated fanbase.\n\nMichael Jackson, the King of Pop, was'
[3] Prompt: 'Very fast wifi network with SSID HELLO', Generated text: '{ \t"ssid": "HELLO", \t"securityProtocol": "WPA2-Personal", \t"bandwidth": "5 GHz" }'
```
- [X] benchmarks to verify no degradation in performance. Ran 32 concurrent requests.
MTP without guided decoding:
```
============ Serving Benchmark Result ============
Backend:                                 BackendType.TRUSS
Traffic request rate:                    inf       
Successful requests:                     32        
Correct requests:                        0         
Benchmark duration (s):                  8.86      
Total input tokens:                      6416      
Total generated tokens:                  8189      
Total generated tokens (retokenized):    8108      
Request throughput (req/s):              3.61      
Input token throughput (tok/s):          724.42    
Output token throughput (tok/s):         924.60    
Output token throughput (retokenized) (tok/s): 915.46    
Total token throughput (tok/s):          1649.02   
Total token throughput (retokenized) (tok/s): 1639.88   
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3671.03   
Median E2E Latency (ms):                 3995.91   
---------------Time to First Token----------------
Mean TTFT (ms):                          270.74    
Median TTFT (ms):                        304.16    
P99 TTFT (ms):                           378.55    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.88     
Median TPOT (ms):                        14.63     
P99 TPOT (ms):                           28.64     
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.85     
Median ITL (ms):                         37.38     
P99 ITL (ms):                            44.99     
==================================================
Report for EvalName.BENCH_SERVING:
===================================
```
MTP with guided coding:
```
============ Serving Benchmark Result ============
Backend:                                 BackendType.TRUSS
Traffic request rate:                    inf       
Successful requests:                     32        
Correct requests:                        0         
Benchmark duration (s):                  8.96      
Total input tokens:                      6416      
Total generated tokens:                  8189      
Total generated tokens (retokenized):    8101      
Request throughput (req/s):              3.57      
Input token throughput (tok/s):          716.40    
Output token throughput (tok/s):         914.37    
Output token throughput (retokenized) (tok/s): 904.54    
Total token throughput (tok/s):          1630.77   
Total token throughput (retokenized) (tok/s): 1620.94   
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3727.56   
Median E2E Latency (ms):                 4075.75   
---------------Time to First Token----------------
Mean TTFT (ms):                          311.44    
Median TTFT (ms):                        299.41    
P99 TTFT (ms):                           344.21    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.52     
Median TPOT (ms):                        14.57     
P99 TPOT (ms):                           19.97     
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.83     
Median ITL (ms):                         37.81     
P99 ITL (ms):                            44.89     
==================================================
Report for EvalName.BENCH_SERVING:
===================================
```

The output token throughput is 920 ± 6 tok/s
<!--
  For each of the categories of requirements, please specify what is required or write "none".

  Pre-release requirements - Are there any changes need to be made or or rolled out before release of this PR?
  - In most cases, before feature flags, Django fields, or internal APIs are deleted, all usages of them should be removed.
  - Link to any PRs that need to be merged and fully deployed before this PR can be merged.

  Post-release requirements - Does anything need to be changed or configured after this PR is merged for it to be fully rolled out?
  - E.g. does a feature flag need to be enabled, a constance value updated, or a management command run?
  - Please include *when* this should happen (e.g. immediately after a deploy, or are there other dependencies or tests that need to take place).
  - Does this change require an image tag update?

  External communication - Does this PR require a docs update, a changelog post, or reaching out to impacted customers?
-->
## :ship: Release requirements

- **Pre-release:** Specify here
- **Post-release:** Specify here
- **External communication:** Specify here
